### PR TITLE
Change council_reference to 9 characters

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -15,7 +15,7 @@ page.search('div.apps_application').each do |a|
   next if a.at('div.app_address').nil?  # No addresses on this DA
 
   address = a.at('div.app_address').at('p').inner_html.split('<br>')
-  council_reference = a.at('div.app_map').inner_html.match(/\d{8}/).to_s
+  council_reference = a.at('div.app_map').inner_html.match(/\d{9}/).to_s
 
   a.search('h6').each do |h|
     case h.inner_text


### PR DESCRIPTION
Hi there, the ntlis.nt.gov.au have changed from 8 to 9 character ID's.
I'm not at all familiar with your codebase (or Ruby) but it seemed that this was a fairly simple fix. If this is more complex please reject, no hurt feelings.
Thanks for the data over the last four years though!

**Background:**
All [planning applications for the NT](https://www.planningalerts.org.au/authorities/northern_territory/applications) when you click on "Read more information" result in a System Error. This is caused because the urls generated are now incorrect.

https://www.ntlis.nt.gov.au/planningPopup/lta.dar.view/10095110  
should be 
https://www.ntlis.nt.gov.au/planningPopup/lta.dar.view/100951104

https://www.ntlis.nt.gov.au/planningPopup/lta.dar.view/10069468  
should be
https://www.ntlis.nt.gov.au/planningPopup/lta.dar.view/100694685

The scraper is set to take 8 digits, but the ILIS DOA UID was recently changed from 8 to 9 characters.